### PR TITLE
fix npm and emberobserver api usage

### DIFF
--- a/app/adapters/addon.js
+++ b/app/adapters/addon.js
@@ -1,6 +1,10 @@
 import DS from 'ember-data';
 
 export default DS.JSONAPIAdapter.extend({
-  host: 'https://emberobserver.com/',
-  namespace: 'api/v2/'
+  host: 'https://emberobserver.com',
+  namespace: 'api/v2',
+
+  pathForType(){
+    return 'autocomplete_data';
+  }
 });

--- a/app/adapters/npm.js
+++ b/app/adapters/npm.js
@@ -2,7 +2,7 @@ import DS from 'ember-data';
 
 export default DS.JSONAPIAdapter.extend({
   host: 'https://api.npms.io',
-  namespace: '',
+  namespace: 'v2',
 
   pathForType(){
     return 'search';

--- a/app/routes/project/detail/install.js
+++ b/app/routes/project/detail/install.js
@@ -30,7 +30,7 @@ export default Ember.Route.extend({
         final: 0
       })));
     } else {
-      packages = this.get('store').query('npm', {term: packageQuery, from: 0, size: 10});
+      packages = this.get('store').query('npm', {q: packageQuery, from: 0, size: 10});
     }
     return packages;
   },

--- a/app/serializers/npm.js
+++ b/app/serializers/npm.js
@@ -6,9 +6,9 @@ export default ApplicationSerializer.extend({
       data: payload.results.map(pkg => {
         const jsonapiPackage = {
           type: 'npm',
-          id: `${pkg.module.name}`,
+          id: `${pkg.package.name}`,
           attributes: {
-            ...pkg.module,
+            ...pkg.package,
             ...pkg.score
           }
         };

--- a/ember-electron/main.js
+++ b/ember-electron/main.js
@@ -1,6 +1,6 @@
 /* eslint-env node */
-const { app, BrowserWindow, protocol, ipcMain } = require('electron');
-const { dirname, join, resolve } = require('path');
+const {app, BrowserWindow, protocol, ipcMain, session} = require('electron');
+const {dirname, join, resolve} = require('path');
 const protocolServe = require('electron-protocol-serve');
 const Hearth = require('./cli/hearth');
 const path = require('path');
@@ -8,7 +8,7 @@ const path = require('path');
 let mainWindow = null;
 
 // Registering a protocol & schema to serve our Ember application
-protocol.registerStandardSchemes(['serve'], { secure: true });
+protocol.registerStandardSchemes(['serve'], {secure: true});
 protocolServe({
   cwd: join(__dirname || resolve(dirname('')), '..', 'ember'),
   app,
@@ -31,6 +31,15 @@ app.on('window-all-closed', () => {
 });
 
 app.on('ready', () => {
+  // enable cors for emberobserver.com and npms.io
+  session.defaultSession.webRequest.onHeadersReceived({
+    urls: ['https://emberobserver.com', 'https://api.npms.io']
+  }, (details, callback) => {
+    const {responseHeaders} = details;
+    responseHeaders['Access-Control-Allow-Origin'] = ['serve://dist'];
+    callback({cancel: false, responseHeaders});
+  });
+
   mainWindow = new BrowserWindow({
     icon: path.join(__dirname, 'cli', 'assets', 'hearth-tray.png'),
     width: 800,


### PR DESCRIPTION
There were some changes in how emberobserver and npms.io exposed their api.
One major change is that I had to disable webSecurity to get CORS to work. 
See https://github.com/felixrieseberg/ember-electron/blob/master/docs/faq/common-issues.md#when-i-make-ajax-requests-they-fail-due-to-cors-problems-access-control-allow-origin-header for implications on security.

This commit also closes #40.